### PR TITLE
Make `email`, `givenName` and `familyName` nullable

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -11,10 +11,10 @@ export interface SignInWithApplePlugin {
 export interface ResponseSignInWithApplePlugin {
   response: {
     user: string;
-    email: string;
-    givenName: string;
-    familyName: string;
+    email: string | null;
+    givenName: string | null;
+    familyName: string | null;
     identityToken: string;
     authorizationCode: string;
-  }
+  };
 }


### PR DESCRIPTION
Apple returns those properties only for the first time when the user grants access. Then after that each time all of those properties will be null.