### PR TITLE
fix(readme): update to SignInWithAppleResponse

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Maintenance Status: Partially Maintained (help wanted)
 import { Plugins } from "@capacitor/core";
 import {
   SignInWithApple,
-  SignInWithApplePluginResponse,
+  SignInWithAppleResponse,
   SignInWithAppleOptions,
 } from "@capacitor-community/apple-sign-in";
 


### PR DESCRIPTION
SignInWithApplePluginResponse is changed to SignInWithAppleResponse at v1.0.0.
Thanks.