### PR TITLE
docs(README): Remove contributors and maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 # Capacitor Sign in With Apple
 
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-
-[![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors-)
-
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
-
 Capacitor plugin to support [Sign in With Apple](https://developer.apple.com/sign-in-with-apple/get-started/)
 
 <!-- Badges -->
@@ -15,16 +9,6 @@ Capacitor plugin to support [Sign in With Apple](https://developer.apple.com/sig
 <a href="https://npmjs.com/package/@capacitor-community/apple-sign-in">
   <img src="https://img.shields.io/npm/l/@capacitor-community/apple-sign-in.svg">
 </a>
-
-## Maintainers
-
-| Maintainer             | GitHub                                      | Social                                      | Sponsoring Company |
-| ---------------------- | ------------------------------------------- | ------------------------------------------- | ------------------ |
-| Max Lynch              | [mlynch](https://github.com/mlynch)         | [@maxlynch](https://twitter.com/maxlynch)   | Ionic              |
-| Jose "Pilito" Martinez | [epicshaggy](https://github.com/epicshaggy) | [@pilito_he](https://twitter.com/pilito_he) |                    |
-| Laszlo Csoka           | [lcsoka](https://github.com/lcsoka)         |                                             |                    |
-
-Maintenance Status: Partially Maintained (help wanted)
 
 ## Installation
 
@@ -63,25 +47,3 @@ SignInWithApple.authorize(options)
 ## Instructions (Android)
 
 Not supported.
-
-## Contributors ✨
-
-Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
-
-<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-<!-- prettier-ignore-start -->
-<!-- markdownlint-disable -->
-<table>
-  <tr>
-    <td align="center"><a href="https://rdlabo.jp"><img src="https://avatars1.githubusercontent.com/u/9690024?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Masahiko Sakakibara</b></sub></a><br /><a href="https://github.com/capacitor-community/apple-sign-in/commits?author=rdlabo" title="Code">💻</a></td>
-    <td align="center"><a href="https://github.com/epicshaggy"><img src="https://avatars0.githubusercontent.com/u/50883345?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Pilito</b></sub></a><br /><a href="https://github.com/capacitor-community/apple-sign-in/commits?author=epicshaggy" title="Code">💻</a></td>
-    <td align="center"><a href="https://github.com/epicshaggy"><img src="https://avatars.githubusercontent.com/u/9068178?v=4?s=100" width="100px;" alt=""/><br /><sub><b>lcsoka</b></sub></a><br /><a href="https://github.com/capacitor-community/apple-sign-in/commits?author=lcsoka" title="Code">💻</a></td>
-  </tr>
-</table>
-
-<!-- markdownlint-restore -->
-<!-- prettier-ignore-end -->
-
-<!-- ALL-CONTRIBUTORS-LIST:END -->
-
-This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!


### PR DESCRIPTION
GitHub now shows the contributors on the right side, and shows all of them while the contributors section only showed 3.
That's automatic and needs no manual updates, so let's remove the list.

Also people on the maintainers list have not been around for a few years, so removing them too.